### PR TITLE
chore: update studiocms to beta.18

### DIFF
--- a/.changeset/fresh-pandas-stop.md
+++ b/.changeset/fresh-pandas-stop.md
@@ -1,0 +1,6 @@
+---
+"@studiocms/socialposter": patch
+"@studiocms/wysiwyg": patch
+---
+
+Update to support beta.18

--- a/packages/studiocms_socialposter/src/index.ts
+++ b/packages/studiocms_socialposter/src/index.ts
@@ -39,113 +39,121 @@ function studiocmsSocialPoster(opts?: Partial<StudioCMSSocialPosterOptions>): St
 	return definePlugin({
 		identifier: packageIdentifier,
 		name: 'StudioCMS Social Poster',
-		studiocmsMinimumVersion: '0.1.0-beta.15',
-		dashboardPages: {
-			user: [
-				{
-					title: {
-						en: 'Share to Social Media',
-						de: 'Share to Social Media',
-						es: 'Share to Social Media',
-						fr: 'Share to Social Media',
+		studiocmsMinimumVersion: '0.1.0-beta.18',
+		hooks: {
+			'studiocms:astro:config': ({ addIntegrations }) => {
+				addIntegrations({
+					name: packageIdentifier,
+					hooks: {
+						'astro:config:setup': (params) => {
+							const { injectRoute } = params;
+
+							addAstroEnvConfig(params, {
+								validateSecrets: true,
+								schema: {
+									BLUESKY_SERVICE: envField.string({
+										context: 'server',
+										access: 'secret',
+										optional: !options.bluesky,
+									}),
+									BLUESKY_USERNAME: envField.string({
+										context: 'server',
+										access: 'secret',
+										optional: !options.bluesky,
+									}),
+									BLUESKY_PASSWORD: envField.string({
+										context: 'server',
+										access: 'secret',
+										optional: !options.bluesky,
+									}),
+									THREADS_USER_ID: envField.string({
+										context: 'server',
+										access: 'secret',
+										optional: !options.threads,
+									}),
+									THREADS_ACCESS_TOKEN: envField.string({
+										context: 'server',
+										access: 'secret',
+										optional: !options.threads,
+									}),
+									TWITTER_API_KEY: envField.string({
+										context: 'server',
+										access: 'secret',
+										optional: !options.twitter,
+									}),
+									TWITTER_API_SECRET: envField.string({
+										context: 'server',
+										access: 'secret',
+										optional: !options.twitter,
+									}),
+									TWITTER_ACCESS_TOKEN: envField.string({
+										context: 'server',
+										access: 'secret',
+										optional: !options.twitter,
+									}),
+									TWITTER_ACCESS_SECRET: envField.string({
+										context: 'server',
+										access: 'secret',
+										optional: !options.twitter,
+									}),
+								},
+							});
+
+							addVirtualImports(params, {
+								name: packageIdentifier,
+								imports: {
+									'studiocms:socialposter/config': `export default ${JSON.stringify(options)}`,
+								},
+							});
+
+							if (options.bluesky) {
+								injectRoute({
+									pattern: '/studiocms_api/socialposter/post-to-bluesky',
+									entrypoint: resolve('./routes/postToBlueSky.js'),
+									prerender: false,
+								});
+							}
+
+							if (options.threads) {
+								injectRoute({
+									pattern: '/studiocms_api/socialposter/post-to-threads',
+									entrypoint: resolve('./routes/postToThreads.js'),
+									prerender: false,
+								});
+							}
+
+							if (options.twitter) {
+								injectRoute({
+									pattern: '/studiocms_api/socialposter/post-to-twitter',
+									entrypoint: resolve('./routes/postToTwitter.js'),
+									prerender: false,
+								});
+							}
+						},
 					},
-					description: 'Share content on Social media',
-					sidebar: 'single',
-					pageBodyComponent: resolve('./pages/socials.astro'),
-					route: 'share',
-					requiredPermissions: 'editor',
-					icon: 'share',
-				},
-			],
-		},
-		integration: {
-			name: packageIdentifier,
-			hooks: {
-				'astro:config:setup': (params) => {
-					const { injectRoute } = params;
-
-					addAstroEnvConfig(params, {
-						validateSecrets: true,
-						schema: {
-							BLUESKY_SERVICE: envField.string({
-								context: 'server',
-								access: 'secret',
-								optional: !options.bluesky,
-							}),
-							BLUESKY_USERNAME: envField.string({
-								context: 'server',
-								access: 'secret',
-								optional: !options.bluesky,
-							}),
-							BLUESKY_PASSWORD: envField.string({
-								context: 'server',
-								access: 'secret',
-								optional: !options.bluesky,
-							}),
-							THREADS_USER_ID: envField.string({
-								context: 'server',
-								access: 'secret',
-								optional: !options.threads,
-							}),
-							THREADS_ACCESS_TOKEN: envField.string({
-								context: 'server',
-								access: 'secret',
-								optional: !options.threads,
-							}),
-							TWITTER_API_KEY: envField.string({
-								context: 'server',
-								access: 'secret',
-								optional: !options.twitter,
-							}),
-							TWITTER_API_SECRET: envField.string({
-								context: 'server',
-								access: 'secret',
-								optional: !options.twitter,
-							}),
-							TWITTER_ACCESS_TOKEN: envField.string({
-								context: 'server',
-								access: 'secret',
-								optional: !options.twitter,
-							}),
-							TWITTER_ACCESS_SECRET: envField.string({
-								context: 'server',
-								access: 'secret',
-								optional: !options.twitter,
-							}),
-						},
-					});
-
-					addVirtualImports(params, {
-						name: packageIdentifier,
-						imports: {
-							'studiocms:socialposter/config': `export default ${JSON.stringify(options)}`,
-						},
-					});
-
-					if (options.bluesky) {
-						injectRoute({
-							pattern: '/studiocms_api/socialposter/post-to-bluesky',
-							entrypoint: resolve('./routes/postToBlueSky.js'),
-							prerender: false,
-						});
-					}
-
-					if (options.threads) {
-						injectRoute({
-							pattern: '/studiocms_api/socialposter/post-to-threads',
-							entrypoint: resolve('./routes/postToThreads.js'),
-							prerender: false,
-						});
-					}
-
-					if (options.twitter) {
-						injectRoute({
-							pattern: '/studiocms_api/socialposter/post-to-twitter',
-							entrypoint: resolve('./routes/postToTwitter.js'),
-							prerender: false,
-						});
-					}
-				},
+				});
+			},
+			'studiocms:config:setup': ({ setDashboard }) => {
+				setDashboard({
+					dashboardPages: {
+						user: [
+							{
+								title: {
+									en: 'Share to Social Media',
+									de: 'Share to Social Media',
+									es: 'Share to Social Media',
+									fr: 'Share to Social Media',
+								},
+								description: 'Share content on Social media',
+								sidebar: 'single',
+								pageBodyComponent: resolve('./pages/socials.astro'),
+								route: 'share',
+								requiredPermissions: 'editor',
+								icon: 'share',
+							},
+						],
+					},
+				});
 			},
 		},
 	});

--- a/packages/studiocms_wysiwyg/src/studio/index.ts
+++ b/packages/studiocms_wysiwyg/src/studio/index.ts
@@ -51,40 +51,48 @@ function studiocmsWYSIWYGStudio(options: StudioCMSWYSIWYGStudioOptions): StudioC
 	return definePlugin({
 		identifier: packageIdentifier,
 		name: 'StudioCMS WYSIWYG (GrapesJS StudioSDK)',
-		studiocmsMinimumVersion: '0.1.0-beta.13',
-		pageTypes: [
-			{
-				identifier: 'studiocms/wysiwyg/studio',
-				label: 'GrapesJS StudioSDK',
-				rendererComponent: resolve('./components/Render.astro'),
-				pageContentComponent: resolve('./components/StudioSDKEditor.astro'),
-			},
-		],
-		integration: {
-			name: packageIdentifier,
-			hooks: {
-				'astro:config:setup': (params) => {
-					addVirtualImports(params, {
-						name: packageIdentifier,
-						imports: {
-							'studiocms:wysiwyg/studio/client': `
-								export const licenseKey = ${JSON.stringify(options.licenseKey)};
-								export const youtubeAPIKey = ${JSON.stringify(options.youtubeAPIKey)};
-								export const googleFontsAPIKey = ${JSON.stringify(options.googleFontsAPIKey)};
-								export * from '${resolve('./utils.js')}';
-							`,
-						},
-					});
+		studiocmsMinimumVersion: '0.1.0-beta.18',
+		hooks: {
+			'studiocms:astro:config': ({ addIntegrations }) => {
+				addIntegrations({
+					name: packageIdentifier,
+					hooks: {
+						'astro:config:setup': (params) => {
+							addVirtualImports(params, {
+								name: packageIdentifier,
+								imports: {
+									'studiocms:wysiwyg/studio/client': `
+										export const licenseKey = ${JSON.stringify(options.licenseKey)};
+										export const youtubeAPIKey = ${JSON.stringify(options.youtubeAPIKey)};
+										export const googleFontsAPIKey = ${JSON.stringify(options.googleFontsAPIKey)};
+										export * from '${resolve('./utils.js')}';
+									`,
+								},
+							});
 
-					params.injectRoute({
-						entrypoint: resolve('./routes/partial.astro'),
-						pattern: '/studiocms_api/wysiwyg_editor/studiosdk/partial',
-						prerender: false,
-					});
-				},
-				'astro:config:done': () => {
-					shared.sanitize = options.sanitize || {};
-				},
+							params.injectRoute({
+								entrypoint: resolve('./routes/partial.astro'),
+								pattern: '/studiocms_api/wysiwyg_editor/studiosdk/partial',
+								prerender: false,
+							});
+						},
+						'astro:config:done': () => {
+							shared.sanitize = options.sanitize || {};
+						},
+					},
+				});
+			},
+			'studiocms:config:setup': ({ setRendering }) => {
+				setRendering({
+					pageTypes: [
+						{
+							identifier: 'studiocms/wysiwyg/studio',
+							label: 'GrapesJS StudioSDK',
+							rendererComponent: resolve('./components/Render.astro'),
+							pageContentComponent: resolve('./components/StudioSDKEditor.astro'),
+						},
+					],
+				});
 			},
 		},
 	});

--- a/packages/studiocms_wysiwyg/src/wysiwyg/index.ts
+++ b/packages/studiocms_wysiwyg/src/wysiwyg/index.ts
@@ -33,28 +33,36 @@ function studiocmsWYSIWYG(options?: StudioCMSWYSIWYGOptions): StudioCMSPlugin {
 	return definePlugin({
 		identifier: packageIdentifier,
 		name: 'StudioCMS WYSIWYG Editor',
-		studiocmsMinimumVersion: '0.1.0-beta.13',
-		pageTypes: [
-			{
-				identifier: 'studiocms/wysiwyg',
-				label: 'WYSIWYG',
-				rendererComponent: resolve('./components/Render.astro'),
-				pageContentComponent: resolve('./components/Editor.astro'),
+		studiocmsMinimumVersion: '0.1.0-beta.18',
+		hooks: {
+			'studiocms:astro:config': ({ addIntegrations }) => {
+				addIntegrations({
+					name: packageIdentifier,
+					hooks: {
+						'astro:config:setup': (params) => {
+							params.injectRoute({
+								entrypoint: resolve('./routes/partial.astro'),
+								pattern: '/studiocms_api/wysiwyg_editor/partial',
+								prerender: false,
+							});
+						},
+						'astro:config:done': () => {
+							shared.sanitize = options?.sanitize || {};
+						},
+					},
+				});
 			},
-		],
-		integration: {
-			name: packageIdentifier,
-			hooks: {
-				'astro:config:setup': (params) => {
-					params.injectRoute({
-						entrypoint: resolve('./routes/partial.astro'),
-						pattern: '/studiocms_api/wysiwyg_editor/partial',
-						prerender: false,
-					});
-				},
-				'astro:config:done': () => {
-					shared.sanitize = options?.sanitize || {};
-				},
+			'studiocms:config:setup': ({ setRendering }) => {
+				setRendering({
+					pageTypes: [
+						{
+							identifier: 'studiocms/wysiwyg',
+							label: 'WYSIWYG',
+							rendererComponent: resolve('./components/Render.astro'),
+							pageContentComponent: resolve('./components/Editor.astro'),
+						},
+					],
+				});
 			},
 		},
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ catalogs:
       specifier: ^9.2.0
       version: 9.2.0
     '@studiocms/blog':
-      specifier: 0.1.0-beta.16
-      version: 0.1.0-beta.16
+      specifier: 0.1.0-beta.18
+      version: 0.1.0-beta.18
     '@studiocms/devapps':
-      specifier: 0.1.0-beta.16
-      version: 0.1.0-beta.16
+      specifier: 0.1.0-beta.18
+      version: 0.1.0-beta.18
     '@types/node':
       specifier: ^22.0.0
       version: 22.13.13
@@ -31,8 +31,8 @@ catalogs:
       specifier: ^0.34.0
       version: 0.34.1
     studiocms:
-      specifier: 0.1.0-beta.16
-      version: 0.1.0-beta.16
+      specifier: 0.1.0-beta.18
+      version: 0.1.0-beta.18
     typescript:
       specifier: ^5.7
       version: 5.8.2
@@ -41,8 +41,8 @@ catalogs:
       specifier: ^5.7.1
       version: 5.7.4
     studiocms:
-      specifier: '>=0.1.0-beta.14'
-      version: 0.1.0-beta.15
+      specifier: '>=0.1.0-beta.18'
+      version: 0.1.0-beta.18
     vite:
       specifier: ^6.2.5
       version: 6.2.6
@@ -122,7 +122,7 @@ importers:
         version: 2.0.3
       studiocms:
         specifier: catalog:min
-        version: 0.1.0-beta.15(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
+        version: 0.1.0-beta.18(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
       twitter-api-v2:
         specifier: ^1.22.0
         version: 1.22.0
@@ -159,7 +159,7 @@ importers:
         version: 0.22.6
       studiocms:
         specifier: catalog:min
-        version: 0.1.0-beta.15(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
+        version: 0.1.0-beta.18(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
       tui-image-editor:
         specifier: ^3.15.3
         version: 3.15.3
@@ -184,10 +184,10 @@ importers:
         version: 9.2.0(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))
       '@studiocms/blog':
         specifier: 'catalog:'
-        version: 0.1.0-beta.16(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(studiocms@0.1.0-beta.16(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)))(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
+        version: 0.1.0-beta.18(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(studiocms@0.1.0-beta.18(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)))(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
       '@studiocms/devapps':
         specifier: 'catalog:'
-        version: 0.1.0-beta.16(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(studiocms@0.1.0-beta.16(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)))(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
+        version: 0.1.0-beta.18(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(studiocms@0.1.0-beta.18(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)))(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
       '@studiocms/socialposter':
         specifier: workspace:*
         version: link:../packages/studiocms_socialposter
@@ -202,7 +202,7 @@ importers:
         version: 0.34.1
       studiocms:
         specifier: 'catalog:'
-        version: 0.1.0-beta.16(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
+        version: 0.1.0-beta.18(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1049,9 +1049,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@fontsource-variable/onest@5.1.1':
-    resolution: {integrity: sha512-Lb1hWJL7z7VZ9oDiHp5/O4tq/tzSQ0md1Luv+RPRnw3WalFoRBdjE9Xw9ibgteEeVlv8fYQ3UTR6ALDwdWxgzQ==}
-
   '@grapesjs/react@2.0.0':
     resolution: {integrity: sha512-RpQhLqqr+6PjPB6bonQ4GgANfc9eoKyqa3SplLKPBoWX8OrzYUg62q5taTbyL7MTT+OzrmAHPOLyPGdqux9+Pg==}
     peerDependencies:
@@ -1668,19 +1665,19 @@ packages:
     engines: {node: '>=8.10'}
     hasBin: true
 
-  '@studiocms/blog@0.1.0-beta.16':
-    resolution: {integrity: sha512-YBkyHhJITSblF3rw+sIuiw5LnBZPTCpVS1KtnfC7/e14Aes0zyo/0T6tpQBtnX33PKw3o3hDSKVMWYPFOqVAHQ==}
+  '@studiocms/blog@0.1.0-beta.18':
+    resolution: {integrity: sha512-TLrmVCG4gXkRrO89kQGv9FJmZqgVukB8z+zsJN5boB532XJIRO8t1Yktv5Z+ZetwyAbSgbQGEfxmttnR74XTMw==}
     peerDependencies:
       astro: ^5.7.1
-      studiocms: 0.1.0-beta.16
+      studiocms: 0.1.0-beta.18
       vite: ^6.2.6
 
-  '@studiocms/devapps@0.1.0-beta.16':
-    resolution: {integrity: sha512-kt8VNXUM4a+cnv/J+xCgYqz1QHkd8X7vPPL0Qkp5o1SHw1LmNIsfK8KBXj9SyC9FfMoCag4zFKN4HAjuy6wdlw==}
+  '@studiocms/devapps@0.1.0-beta.18':
+    resolution: {integrity: sha512-uw4QW7zPEBd72Wtsmgne1OyE/6YUl5612Sw1/B2dFcBgVeE6d6IQF2vx/jR2tl9uG9cyN0orrv9C+PST7El0Ug==}
     peerDependencies:
       '@astrojs/db': ^0.14.10
       astro: ^5.7.1
-      studiocms: 0.1.0-beta.16
+      studiocms: 0.1.0-beta.18
       vite: ^6.2.6
     peerDependenciesMeta:
       studiocms:
@@ -2621,6 +2618,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deepmerge-ts@7.1.5:
+    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+    engines: {node: '>=16.0.0'}
 
   default-browser-id@5.0.0:
     resolution: {integrity: sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==}
@@ -3662,6 +3663,9 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
+  jose@6.0.11:
+    resolution: {integrity: sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==}
+
   js-base64@3.7.7:
     resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
 
@@ -4188,8 +4192,8 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
-  nodemailer@6.10.0:
-    resolution: {integrity: sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA==}
+  nodemailer@7.0.3:
+    resolution: {integrity: sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==}
     engines: {node: '>=6.0.0'}
 
   nopt@1.0.10:
@@ -5086,21 +5090,8 @@ packages:
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
-  studiocms@0.1.0-beta.15:
-    resolution: {integrity: sha512-lsxV/sDl27GtZJ62tKF0HlZ99U0YkkQ4M2XQmiofqItZFLyJ42bv8XsRhPs9KY2DHoQLXsP4XRRkIiUUGgBjyg==}
-    hasBin: true
-    peerDependencies:
-      '@astrojs/db': ^0.14.10
-      '@astrojs/markdown-remark': ^6.3.1
-      '@astrojs/web-vitals': ^3.0.1
-      astro: ^5.6.0
-      vite: ^6.2.5
-    peerDependenciesMeta:
-      '@astrojs/web-vitals':
-        optional: true
-
-  studiocms@0.1.0-beta.16:
-    resolution: {integrity: sha512-7sufxMzBfMMxikKiHJ+zmkK5E60BTIdkO0OGwfwUY1GTALUi9VQEPgqSa+nrj3ig3bTHli07+5GpYdWjUTrKzw==}
+  studiocms@0.1.0-beta.18:
+    resolution: {integrity: sha512-QAbvxSgCMGqjb7Dc2TbOxYQHvnlIvgAaOyLcXDhIOOp44BrTdXemidJlpciM47HT8IqqzXHOuioYKSNEia2O6A==}
     hasBin: true
     peerDependencies:
       '@astrojs/db': ^0.14.10
@@ -6942,8 +6933,6 @@ snapshots:
   '@esbuild/win32-x64@0.25.1':
     optional: true
 
-  '@fontsource-variable/onest@5.1.1': {}
-
   '@grapesjs/react@2.0.0(grapesjs@0.22.6)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@types/react': 19.0.12
@@ -7535,15 +7524,15 @@ snapshots:
       ignore: 5.3.2
       p-map: 4.0.0
 
-  '@studiocms/blog@0.1.0-beta.16(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(studiocms@0.1.0-beta.16(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)))(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))':
+  '@studiocms/blog@0.1.0-beta.18(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(studiocms@0.1.0-beta.18(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)))(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))':
     dependencies:
       '@astrojs/rss': 4.0.11
       astro: 5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2)
       astro-integration-kit: 0.18.0(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))
-      studiocms: 0.1.0-beta.16(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
+      studiocms: 0.1.0-beta.18(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
       vite: 6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)
 
-  '@studiocms/devapps@0.1.0-beta.16(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(studiocms@0.1.0-beta.16(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)))(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))':
+  '@studiocms/devapps@0.1.0-beta.18(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(studiocms@0.1.0-beta.18(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)))(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))':
     dependencies:
       '@astrojs/db': 0.14.11(@types/react@19.0.12)(react@19.0.0)
       astro: 5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2)
@@ -7553,7 +7542,7 @@ snapshots:
       turndown: 7.2.0
       vite: 6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)
     optionalDependencies:
-      studiocms: 0.1.0-beta.16(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
+      studiocms: 0.1.0-beta.18(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
 
   '@studiocms/markdown-remark-processor@1.2.0':
     dependencies:
@@ -8674,6 +8663,8 @@ snapshots:
   deep-is@0.1.4:
     optional: true
 
+  deepmerge-ts@7.1.5: {}
+
   default-browser-id@5.0.0: {}
 
   default-browser@5.2.1:
@@ -9755,6 +9746,8 @@ snapshots:
 
   jiti@2.4.2: {}
 
+  jose@6.0.11: {}
+
   js-base64@3.7.7: {}
 
   js-tokens@4.0.0: {}
@@ -10468,7 +10461,7 @@ snapshots:
 
   node-releases@2.0.19: {}
 
-  nodemailer@6.10.0: {}
+  nodemailer@7.0.3: {}
 
   nopt@1.0.10:
     dependencies:
@@ -11610,95 +11603,7 @@ snapshots:
 
   strnum@1.1.2: {}
 
-  studiocms@0.1.0-beta.15(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)):
-    dependencies:
-      '@astrojs/db': 0.14.11(@types/react@19.0.12)(react@19.0.0)
-      '@astrojs/markdown-remark': 6.3.1
-      '@clack/core': 0.4.1
-      '@clack/prompts': 0.9.1
-      '@cloudinary/url-gen': 1.21.0
-      '@commander-js/extra-typings': 13.1.0(commander@13.1.0)
-      '@fontsource-variable/onest': 5.1.1
-      '@iconify-json/flat-color-icons': 1.2.1
-      '@iconify-json/simple-icons': 1.2.29
-      '@inox-tools/inline-mod': 2.0.3(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
-      '@inox-tools/runtime-logger': 0.4.2(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))
-      '@libsql/client': 0.15.3
-      '@nanostores/i18n': 0.12.2(nanostores@0.11.4)
-      '@nanostores/persistent': 0.10.2(nanostores@0.11.4)
-      '@oslojs/binary': 1.0.0
-      '@oslojs/crypto': 1.0.1
-      '@oslojs/encoding': 1.1.0
-      '@studiocms/markdown-remark-processor': 1.2.0
-      '@studiocms/ui': 0.4.16(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0))
-      ansi-escapes: 7.0.0
-      arctic: 3.5.0
-      astro: 5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2)
-      astro-integration-kit: 0.18.0(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))
-      boxen: 8.0.1
-      chalk: 5.4.1
-      cli-cursor: 5.0.0
-      codemirror: 5.65.19
-      commander: 13.1.0
-      diff: 7.0.0
-      diff2html: 3.4.51
-      dompurify: 3.2.4
-      dotenv: 16.5.0
-      drizzle-orm: 0.31.4(@libsql/client@0.15.3)(@types/react@19.0.12)(react@19.0.0)
-      figlet: 1.8.0
-      fuse.js: 7.1.0
-      is-unicode-supported: 2.1.0
-      katex: 0.16.21
-      lodash: 4.17.21
-      mdast-util-from-markdown: 2.0.2
-      mdast-util-to-markdown: 2.1.2
-      mdast-util-to-string: 4.0.0
-      mrmime: 2.0.1
-      nanostores: 0.11.4
-      nodemailer: 6.10.0
-      semver: 7.7.1
-      slice-ansi: 7.1.0
-      socks: 2.8.4
-      strip-ansi: 7.1.0
-      suneditor: 2.47.5
-      three: 0.170.0
-      ultrahtml: 1.6.0
-      unist-util-visit: 5.0.0
-      vite: 6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)
-      wrap-ansi: 9.0.0
-    transitivePeerDependencies:
-      - '@aws-sdk/client-rds-data'
-      - '@cloudflare/workers-types'
-      - '@electric-sql/pglite'
-      - '@neondatabase/serverless'
-      - '@op-engineering/op-sqlite'
-      - '@opentelemetry/api'
-      - '@planetscale/database'
-      - '@prisma/client'
-      - '@tidbcloud/serverless'
-      - '@types/better-sqlite3'
-      - '@types/pg'
-      - '@types/react'
-      - '@types/sql.js'
-      - '@vercel/postgres'
-      - '@xata.io/client'
-      - better-sqlite3
-      - bufferutil
-      - bun-types
-      - expo-sqlite
-      - knex
-      - kysely
-      - mysql2
-      - pg
-      - postgres
-      - prisma
-      - react
-      - sql.js
-      - sqlite3
-      - supports-color
-      - utf-8-validate
-
-  studiocms@0.1.0-beta.16(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)):
+  studiocms@0.1.0-beta.18(@astrojs/db@0.14.11(@types/react@19.0.12)(react@19.0.0))(@astrojs/markdown-remark@6.3.1)(@types/react@19.0.12)(astro@5.7.4(@types/node@22.13.13)(jiti@2.4.2)(rollup@4.37.0)(terser@5.39.0)(typescript@5.8.2))(react@19.0.0)(vite@6.2.6(@types/node@22.13.13)(jiti@2.4.2)(terser@5.39.0)):
     dependencies:
       '@astrojs/db': 0.14.11(@types/react@19.0.12)(react@19.0.0)
       '@astrojs/markdown-remark': 6.3.1
@@ -11726,21 +11631,22 @@ snapshots:
       chalk: 5.4.1
       codemirror: 5.65.19
       commander: 13.1.0
+      deepmerge-ts: 7.1.5
       diff: 7.0.0
       diff2html: 3.4.51
       dompurify: 3.2.4
       dotenv: 16.5.0
       drizzle-orm: 0.31.4(@libsql/client@0.15.3)(@types/react@19.0.12)(react@19.0.0)
       fuse.js: 7.1.0
+      jose: 6.0.11
       katex: 0.16.21
-      lodash: 4.17.21
       magicast: 0.3.5
       mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
       mdast-util-to-string: 4.0.0
       mrmime: 2.0.1
       nanostores: 0.11.4
-      nodemailer: 6.10.0
+      nodemailer: 7.0.3
       package-manager-detector: 1.1.0
       semver: 7.7.1
       socks: 2.8.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,20 +2,20 @@ catalog:
   '@astrojs/db': ^0.14.11
   '@astrojs/check': ^0.9.4
   '@astrojs/node': ^9.2.0
-  '@studiocms/blog': 0.1.0-beta.16
-  '@studiocms/devapps': 0.1.0-beta.16
+  '@studiocms/blog': 0.1.0-beta.18
+  '@studiocms/devapps': 0.1.0-beta.18
   '@types/node': ^22.0.0
   astro: ^5.7.1
   astro-integration-kit: ^0.18
   sharp: ^0.34.0
-  studiocms: 0.1.0-beta.16
+  studiocms: 0.1.0-beta.18
   typescript: ^5.7
   vite: ^6.2.5
 
 catalogs:
   min:
     astro: ^5.7.1
-    studiocms: ">=0.1.0-beta.14"
+    studiocms: ">=0.1.0-beta.18"
     '@astrojs/db': ^0.14.7
     vite: ^6.2.5
 


### PR DESCRIPTION

- Updated minimum version for StudioCMS WYSIWYG and Blog to 0.1.0-beta.18.
- Refactored integration hooks for better configuration handling in WYSIWYG and Blog.
- Added new route patterns for WYSIWYG and Blog integrations.
- Updated pnpm-lock.yaml and pnpm-workspace.yaml to reflect new version dependencies.
- Created a changeset for the patch release to support beta.18.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated plugin configuration to use a new hooks-based integration pattern for improved alignment with recent platform changes.
  - Consolidated dashboard and page type setup into dedicated configuration hooks.
  - Raised minimum required StudioCMS version to beta.18 for relevant packages.
- **Chores**
  - Updated version requirements and workspace metadata to support StudioCMS beta.18.
  - Added documentation for patch updates to package changelogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->