### PR TITLE
feat: Bump pnpm to 10.17 and configure minimumReleaseAge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,5 +35,6 @@
       "matchPackageNames": ["drizzle-orm"],
       "enabled": false
     }
-  ]
+  ],
+  "minimumReleaseAge": "3 days"
 }

--- a/.prototools
+++ b/.prototools
@@ -1,6 +1,6 @@
 biome = "1.9.4"
 node = "20.14.0"
-pnpm = "9.5.0"
+pnpm = "10.17.0"
 
 [plugins]
 biome = "source:https://raw.githubusercontent.com/Phault/proto-toml-plugins/main/biome/plugin.toml"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "private": true,
-  "packageManager": "pnpm@9.5.0",
+  "packageManager": "pnpm@10.17.0",
   "engines": {
     "node": "20.14.0"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,3 +23,10 @@ packages:
   - "packages/*"
   - "playground"
   - "build-scripts"
+
+minimumReleaseAge: 4320
+
+minimumReleaseAgeExclude:
+  - studiocms
+  - '@studiocms/*'
+  - '@withstudiocms/*'


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

This PR bumps the PNPM version to 10.17.0 and enables the new `minimumReleaseAge` feature.